### PR TITLE
토근 응답시 access token 과 refresh token 만료시간 응답하도록 응답값 추가

### DIFF
--- a/src/main/java/kr/polymarket/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/kr/polymarket/domain/user/dto/LoginResponseDto.java
@@ -3,24 +3,16 @@ package kr.polymarket.domain.user.dto;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 @ApiModel(description = "로그인 응답 모델")
-public class LoginResponseDto {
+public class LoginResponseDto extends TokenResponseDto {
 
     @ApiModelProperty(name = "사용자 ID", notes = "사용자 식별자", example = "1")
     private Long userId;
 
-    @ApiModelProperty(name = "access token",
-            notes = "인증이 필요한 API 요청시 Header(X-AUTH-TOKEN) 에 첨부해서 보내는 인증용 jwt access token",
-            example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImlhdCI6MTY1MjM2MDc0NCwiZXhwIjoxNjUyMzYyNTQ0fQ.N7zfQD4qVOPkcA1Iy3_QZrMXmxB-pwyy9ciIcx2u7EEBBKTHD2VYizmU01conO8L37CVuLwPYAhoNqmcjBXmLg")
-    private String accessToken;
-
-    @ApiModelProperty(name = "refresh token",
-            notes = "사용자 식별자", example
-            = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImlhdCI6MTY1MjM2Mjg4NiwiZXhwIjoxNjUyOTY3Njg2fQ.vIkbIyND5A8ULrMwK08_SCXRMTJD8ErllQNNS9AeWLp6-ZRd_7HkV-vUYrGAjWLIp6W8VamB9_B9G7XM-9sN")
-    private String refreshToken;
 }

--- a/src/main/java/kr/polymarket/domain/user/dto/TokenResponseDto.java
+++ b/src/main/java/kr/polymarket/domain/user/dto/TokenResponseDto.java
@@ -1,25 +1,38 @@
 package kr.polymarket.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 @ApiModel(description = "인증 토큰 응답 모델")
 public class TokenResponseDto {
 
     @ApiModelProperty(name = "access token",
             notes = "인증이 필요한 API 요청시 Header(X-AUTH-TOKEN) 에 첨부해서 보내는 인증용 jwt access token",
             example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImlhdCI6MTY1MjM2MDc0NCwiZXhwIjoxNjUyMzYyNTQ0fQ.N7zfQD4qVOPkcA1Iy3_QZrMXmxB-pwyy9ciIcx2u7EEBBKTHD2VYizmU01conO8L37CVuLwPYAhoNqmcjBXmLg")
-    String accessToken;
+    private String accessToken;
 
     @ApiModelProperty(name = "refresh token",
-            notes = "사용자 식별자", example
+            notes = "access token 갱신을 위해 사용하는 token, POST /users/token/refresh with Header(X-REFRESH-TOKEN)으로 요청할떄 필요", example
             = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImlhdCI6MTY1MjM2Mjg4NiwiZXhwIjoxNjUyOTY3Njg2fQ.vIkbIyND5A8ULrMwK08_SCXRMTJD8ErllQNNS9AeWLp6-ZRd_7HkV-vUYrGAjWLIp6W8VamB9_B9G7XM-9sN")
-    String refreshToken;
+    private String refreshToken;
+
+
+    @ApiModelProperty(name = "access token 만료일",
+            notes = "access token 만료일", example = "2022-03-30 12:30:32")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime accessTokenExpiryDateTime;
+
+    @ApiModelProperty(name = "refresh token 만료일",
+            notes = "refresh token 만료일", example = "2022-03-30 12:30:32")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime refreshTokenExpiryDateTime;
 }

--- a/src/main/java/kr/polymarket/domain/user/service/UserAuthService.java
+++ b/src/main/java/kr/polymarket/domain/user/service/UserAuthService.java
@@ -3,18 +3,22 @@ package kr.polymarket.domain.user.service;
 import kr.polymarket.domain.user.dto.LoginRequestDto;
 import kr.polymarket.domain.user.dto.LoginResponseDto;
 import kr.polymarket.domain.user.dto.TokenResponseDto;
-import kr.polymarket.domain.user.repository.RedisKeyPrefix;
 import kr.polymarket.domain.user.entity.User;
 import kr.polymarket.domain.user.exception.InvalidRefreshTokenException;
 import kr.polymarket.domain.user.exception.SignInFailureException;
 import kr.polymarket.domain.user.exception.UserNotFoundException;
+import kr.polymarket.domain.user.repository.RedisKeyPrefix;
 import kr.polymarket.domain.user.repository.RedisRepository;
 import kr.polymarket.domain.user.repository.UserRepository;
+import kr.polymarket.global.config.security.jwt.JwtClaimSet;
 import kr.polymarket.global.config.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -37,13 +41,20 @@ public class UserAuthService {
         if (!passwordEncoder.matches(loginRequestDto.getPassword(), user.getPassword()))
             throw new SignInFailureException();
 
-        String refreshToken = jwtTokenProvider.createRefreshToken(loginRequestDto.getEmail());
-        redisService.setDataWithExpiration(RedisKeyPrefix.REFRESH.buildKey(user.getEmail()), refreshToken,
+        // access token 생성
+        JwtClaimSet accessTokenSet = jwtTokenProvider.createToken(loginRequestDto.getEmail());
+
+        // refresh token 생성 및 저장
+        JwtClaimSet refreshTokenSet = jwtTokenProvider.createRefreshToken(loginRequestDto.getEmail());
+        redisService.setDataWithExpiration(RedisKeyPrefix.REFRESH.buildKey(user.getEmail()), refreshTokenSet.getToken(),
                 JwtTokenProvider.REFRESH_TOKEN_VALID_TIME);
+
         return LoginResponseDto.builder()
                 .userId(user.getId())
-                .accessToken(jwtTokenProvider.createToken(loginRequestDto.getEmail()))
-                .refreshToken(refreshToken)
+                .accessToken(accessTokenSet.getToken())
+                .refreshToken(refreshTokenSet.getToken())
+                .accessTokenExpiryDateTime(accessTokenSet.getClaims().getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
+                .refreshTokenExpiryDateTime(refreshTokenSet.getClaims().getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
                 .build();
     }
 
@@ -59,12 +70,21 @@ public class UserAuthService {
             throw new InvalidRefreshTokenException();
 
         User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
-        String newAccessToken = jwtTokenProvider.createToken(user.getEmail());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+
+        // 새로운 access token 발급
+        JwtClaimSet newAccessTokenSet = jwtTokenProvider.createToken(user.getEmail());
+
+        // 새로운 refresh token 발급 및 저장
+        JwtClaimSet newRefreshTokenSet = jwtTokenProvider.createRefreshToken(user.getEmail());
         redisService.setDataWithExpiration(RedisKeyPrefix.REFRESH.buildKey(user.getEmail()),
                 refreshToken, JwtTokenProvider.REFRESH_TOKEN_VALID_TIME);
 
-        return new TokenResponseDto(newAccessToken, newRefreshToken);
+        return TokenResponseDto.builder()
+                .accessToken(newAccessTokenSet.getToken())
+                .refreshToken(newRefreshTokenSet.getToken())
+                .accessTokenExpiryDateTime(newAccessTokenSet.getClaims().getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
+                .refreshTokenExpiryDateTime(newRefreshTokenSet.getClaims().getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
+                .build();
     }
 }
 

--- a/src/main/java/kr/polymarket/global/config/security/jwt/JwtClaimSet.java
+++ b/src/main/java/kr/polymarket/global/config/security/jwt/JwtClaimSet.java
@@ -1,0 +1,15 @@
+package kr.polymarket.global.config.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class JwtClaimSet {
+
+    private String token;
+
+    private Claims claims;
+}

--- a/src/main/java/kr/polymarket/global/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/kr/polymarket/global/config/security/jwt/JwtTokenProvider.java
@@ -37,28 +37,38 @@ public class JwtTokenProvider {
     }
 
     // 토큰 키는 중복되지않는 값인 email로 지정, H512알고리즘 적용, 토큰유표시간 설정(발급순간부터 30분)
-    public String createToken(String email) {
-        Claims claims = Jwts.claims().setSubject(email);
+    public JwtClaimSet createToken(String email) {
         Date now = new Date();
-
-        return Jwts.builder()
-                .setClaims(claims)
+        Claims claims = Jwts.claims()
+                .setSubject(email)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + TOKEN_VALID_TIME))
-                .signWith(SignatureAlgorithm.HS512, secretKey)
-                .compact();
+                .setExpiration(new Date(now.getTime() + TOKEN_VALID_TIME));
+
+        return JwtClaimSet.builder()
+                .token(Jwts.builder()
+                        .setClaims(claims)
+                        .signWith(SignatureAlgorithm.HS512, secretKey)
+                        .compact()
+                )
+                .claims(claims)
+                .build();
     }
 
-    public String createRefreshToken(String email) {
-        Claims claims = Jwts.claims().setSubject(email);
+    public JwtClaimSet createRefreshToken(String email) {
         Date now = new Date();
-
-        return Jwts.builder()
-                .setClaims(claims)
+        Claims claims = Jwts.claims()
+                .setSubject(email)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALID_TIME))
-                .signWith(SignatureAlgorithm.HS512, secretKey)
-                .compact();
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALID_TIME));
+
+        return JwtClaimSet.builder()
+                .token(Jwts.builder()
+                        .setClaims(claims)
+                        .signWith(SignatureAlgorithm.HS512, secretKey)
+                        .compact()
+                )
+                .claims(claims)
+                .build();
     }
 
 

--- a/src/test/java/kr/polymarket/global/config/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/kr/polymarket/global/config/security/jwt/JwtTokenProviderTest.java
@@ -36,10 +36,10 @@ public class JwtTokenProviderTest {
     void access_token_생성_및_파싱_테스트() {
         // given
         final String email = "test@email.com";
-        String accessToken = jwtTokenProvider.createToken(email);
+        JwtClaimSet accessToken = jwtTokenProvider.createToken(email);
 
         // when
-        String parsedEmail = jwtTokenProvider.getUserEmail(accessToken);
+        String parsedEmail = jwtTokenProvider.getUserEmail(accessToken.getToken());
 
         // then
         assertThat(parsedEmail).isEqualTo(email);
@@ -49,10 +49,10 @@ public class JwtTokenProviderTest {
     void refresh_token_생성_테스트() {
         // given
         final String email = "test@email.com";
-        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+        JwtClaimSet refreshToken = jwtTokenProvider.createRefreshToken(email);
 
         // when
-        String parsedEmail = jwtTokenProvider.getUserEmail(refreshToken);
+        String parsedEmail = jwtTokenProvider.getUserEmail(refreshToken.getToken());
 
         // then
         assertThat(parsedEmail).isEqualTo(email);


### PR DESCRIPTION
토근 응답시 access token 과 refresh token 만료시간 응답하도록 응답값 추가
- 클라이언트 사이드에서 jwt 인증 라이프사이클을 관리할 수 있도록 토큰 발급시 토큰 만료시간을 넘겨주도록 했음


cf) https://www.notion.so/b0bef2d67b5a4c05834c10e913139011