### PR TITLE
도커 컨테이너 서버 시간대 Asia/Seoul로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
 FROM azul/zulu-openjdk:11
+
+# timezone
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 COPY build/libs/*.jar /app.jar
 ENTRYPOINT [ "java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app.jar" ]


### PR DESCRIPTION
민준아 토큰 만료시간 관련해서 개발 테스트에서 테스트 결과 개발서버에서 실행되는 도커컨테이너의 기본 시간대가 Etc/UTC로 설정되어 있어서 한국 시간대로 통일 시켰어